### PR TITLE
Add mongodb_version variable to playbooks

### DIFF
--- a/.github/workflows/CI-etc.yml
+++ b/.github/workflows/CI-etc.yml
@@ -204,7 +204,7 @@ jobs:
             mongodb5
             mongodb6
 
-            [rs1]
+            [rs2]
             mongodb7
             mongodb8
             mongodb9
@@ -220,7 +220,7 @@ jobs:
         run: ansible all -i mongo_inventory.inv -c docker -m raw -a "yum install sudo -y || apt install sudo -y"
         working-directory: AutomatingMongoDBWithAnsible/playbooks/add_shard
 
-      - name: Run upgrade playbook
+      - name: Run add shard playbook
         run: ansible-playbook -i mongo_inventory.inv -c docker add_shard.yml
         working-directory: AutomatingMongoDBWithAnsible/playbooks/add_shard
         env:

--- a/playbooks/add_shard/mongodb.yml
+++ b/playbooks/add_shard/mongodb.yml
@@ -7,6 +7,7 @@
     - role: "community.mongodb.mongodb_linux"
     - role: "community.mongodb.mongodb_selinux"
     - role: "community.mongodb.mongodb_repository"
+      mongodb_version: "4.2"
     - { role: "community.mongodb.mongodb_mongod", mongod_port: 27018, sharding: true, repl_set_name: "rs2" }
 
   tasks:
@@ -29,8 +30,8 @@
       community.mongodb.mongodb_replicaset:
         login_database: "admin"
         login_host: localhost
-        login_port: 27018  
-        replica_set: rs2 
+        login_port: 27018
+        replica_set: rs2
         members:
           - mongodb7.local:27018
           - mongodb8.local:27018
@@ -50,7 +51,7 @@
         login_password: "{{ admin_user_password }}"
         replica_set: rs2
         poll: 10
-        interval: 10 
+        interval: 10
       register: rs
 
     - debug:

--- a/playbooks/replicaset/mongodb.yml
+++ b/playbooks/replicaset/mongodb.yml
@@ -7,6 +7,7 @@
     - role: "community.mongodb.mongodb_linux"
     - role: "community.mongodb.mongodb_selinux"
     - role: "community.mongodb.mongodb_repository"
+      mongodb_version: "4.2"
     - role: "community.mongodb.mongodb_mongod"
 
   tasks:

--- a/playbooks/sharded_cluster/mongodb.yml
+++ b/playbooks/sharded_cluster/mongodb.yml
@@ -7,10 +7,11 @@
     - role: "community.mongodb.mongodb_linux"
     - role: "community.mongodb.mongodb_selinux"
     - role: "community.mongodb.mongodb_repository"
+      mongodb_version: "4.2"
     - { role: "community.mongodb.mongodb_mongod", sharding: true, mongod_port: 27018 }
 
   tasks:
-    
+
     - name: Ensure python3 is available
       package:
         name: python3

--- a/playbooks/sharded_cluster/mongos.yml
+++ b/playbooks/sharded_cluster/mongos.yml
@@ -12,6 +12,7 @@
     - role: "community.mongodb.mongodb_linux"
     - role: "community.mongodb.mongodb_selinux"
     - role: "community.mongodb.mongodb_repository"
+      mongodb_version: "4.2"
     - role: "community.mongodb.mongodb_mongos"
     - role: "community.mongodb.mongodb_config"
 

--- a/playbooks/standalone/mongodb.yml
+++ b/playbooks/standalone/mongodb.yml
@@ -7,6 +7,7 @@
     - role: "community.mongodb.mongodb_linux"
     - role: "community.mongodb.mongodb_selinux"
     - role: "community.mongodb.mongodb_repository"
+      mongodb_version: "4.2"
     - { role: community.mongodb.mongodb_mongod, replicaset: false, sharding: false }
 
   tasks:


### PR DESCRIPTION
Adds the mongodb_version to the playbooks and sets it to 4.2. We increased the default in the collections to 4.4 and this broke some stuff.